### PR TITLE
Prevent closers from opening a new modal

### DIFF
--- a/caldera-modals.js
+++ b/caldera-modals.js
@@ -376,7 +376,7 @@
 
 
 
-	$(document).on('click', '[data-modal]', function( e ){
+	$(document).on('click', '[data-modal]:not(.caldera-modal-closer)', function( e ){
 		e.preventDefault();
 		$(this).calderaModal();
 	});


### PR DESCRIPTION
Overlooked before that anything with data-modal was considered an
opener, so closers were opening a blank modal then closing both.
